### PR TITLE
Adding numerical dice total to roll results

### DIFF
--- a/roll/src/lib.rs
+++ b/roll/src/lib.rs
@@ -8,7 +8,19 @@ use crate::interpreter::Ast;
 pub use crate::parser::*;
 pub use crate::roll::*;
 pub use rand_core;
+use core::fmt;
 use std::collections::HashMap;
+
+pub struct RollResult {
+    pub string_result: String,
+    pub dice_total: crate::interpreter::Value,
+}
+
+impl fmt::Display for RollResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.string_result)
+    }
+}
 
 const STAT_ROLL: &str = "4d6l";
 pub fn roll_stats() -> String {
@@ -30,7 +42,7 @@ pub fn roll_stats() -> String {
     res
 }
 
-pub fn roll_inline(s: &str, advanced: bool) -> Result<String, String> {
+pub fn roll_inline(s: &str, advanced: bool) -> Result<RollResult, String> {
     let mut p = Parser::new(s);
     p.advanced = advanced;
 
@@ -47,7 +59,8 @@ pub fn roll_inline(s: &str, advanced: bool) -> Result<String, String> {
     }
 
     let res = replace_rolls(copy, &map, |roll| format!("{:?}", roll.vals));
-    Ok(format!("{} = {} = {}", s, res, total))
+    let result: RollResult = RollResult { string_result: format!("{} = {} = {}", s, res, total), dice_total: total };
+    Ok(result)
 }
 
 fn replace_rolls(ast: Ast, lookup: &HashMap<u64, Roll>, func: fn(&Roll) -> String) -> Ast {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -39,7 +39,7 @@ pub struct JsRolls {
 
 #[wasm_bindgen]
 pub fn roll_dice_short(s: &str, advanced: bool) -> Result<String, JsValue> {
-    roll_inline(s, advanced).map_err(|s| JsValue::from("\n".to_string() + &s))
+    roll_inline(s, advanced).map_err(|s| JsValue::from("\n".to_string() + &s)).map(|result| result.string_result)
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
Getting the string results from a dice roll are fine when you're simply
outputting the result. However, to do any "real work" with the results,
I need the value of the roll in a numerical fashion as well. I've added
a new struct so that calling methods can now choose which to use, and
the struct can still be printed as a string like the old result. Now I
can roll a dice and use the result as a number, which is much easier to
work with programatically.

I've ran `cargo test` and also tested the roll CLI command. I wasn't able to test the wasm stuff, but presumably should be fine given the test coverage.